### PR TITLE
Fix gradle 8 issues

### DIFF
--- a/android/src/main/java/com/photo/gallery/RNPhotoGalleryModule.java
+++ b/android/src/main/java/com/photo/gallery/RNPhotoGalleryModule.java
@@ -687,7 +687,11 @@ public class RNPhotoGalleryModule extends ReactContextBaseJavaModule {
                                 + photoUri.toString(),
                         e);
             }
-            retriever.release();
+            try {
+                retriever.release();
+            } catch (IOException e) {
+                // Do nothing. We can't handle this, and this is usually a system problem
+            }
         }
 
         if (photoDescriptor != null) {
@@ -754,7 +758,11 @@ public class RNPhotoGalleryModule extends ReactContextBaseJavaModule {
                                         + photoUri.toString(),
                                 e);
                     }
-                    retriever.release();
+                    try {
+                        retriever.release();
+                    } catch (IOException e) {
+                        // Do nothing. We can't handle this, and this is usually a system problem
+                    }
                 } else {
                     BitmapFactory.Options options = new BitmapFactory.Options();
                     // Set inJustDecodeBounds to true so we don't actually load the Bitmap, but only get its

--- a/android/src/main/java/com/photo/gallery/RNPhotoGalleryModule.java
+++ b/android/src/main/java/com/photo/gallery/RNPhotoGalleryModule.java
@@ -155,7 +155,7 @@ public class RNPhotoGalleryModule extends ReactContextBaseJavaModule {
                     // Uri mediaContentUri = resolver
                     //         .insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, mediaDetails);
 
-                    Uri mediaContentUri = isVideo    
+                    Uri mediaContentUri = "video".equals(mOptions.getString("type"))    
                         ? resolver.insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, mediaDetails)
                         : resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, mediaDetails);
 

--- a/android/src/main/java/com/photo/gallery/RNPhotoGalleryModule.java
+++ b/android/src/main/java/com/photo/gallery/RNPhotoGalleryModule.java
@@ -152,8 +152,13 @@ public class RNPhotoGalleryModule extends ReactContextBaseJavaModule {
                     mediaDetails.put(Images.Media.DISPLAY_NAME, source.getName());
                     mediaDetails.put(Images.Media.IS_PENDING, 1);
                     ContentResolver resolver = mContext.getContentResolver();
-                    Uri mediaContentUri = resolver
-                            .insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, mediaDetails);
+                    // Uri mediaContentUri = resolver
+                    //         .insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, mediaDetails);
+
+                    Uri mediaContentUri = isVideo    
+                        ? resolver.insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, mediaDetails)
+                        : resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, mediaDetails);
+
                     output = resolver.openOutputStream(mediaContentUri);
                     input = new FileInputStream(source);
                     FileUtils.copy(input, output);


### PR DESCRIPTION
Was getting compile issues with RN 0.71, which requires gradle 8.    

```
Error: Command failed: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
~/node_modules/@react-native-community/cameraroll/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java:650: error: unreported exception IOException; must be caught or declared to be thrown
      retriever.release();
                       ^
~/node_modules/@react-native-community/cameraroll/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java:713: error: unreported exception IOException; must be caught or declared to be thrown
          retriever.release();
                           ^
Note: ~/node_modules/@react-native-community/cameraroll/android/src/main/java/com/reactnativecommunity/cameraroll/CameraRollModule.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
2 errors
```

It essentially brings over this PR: 
https://github.com/react-native-cameraroll/react-native-cameraroll/pull/419

Also fixes an error that was happening when trying to save videos to android gallery:
```
Save video error on Android: MIME type video/mp4 cannot be inserted into content://media/external/images/media; expected MIME type under image/*
```

